### PR TITLE
Change api

### DIFF
--- a/examples/rest_api/mlflow_tracking_rest_api.py
+++ b/examples/rest_api/mlflow_tracking_rest_api.py
@@ -21,7 +21,7 @@ _DEFAULT_USER_ID = "unknown"
 
 class MLflowTrackingRestApi:
     def __init__(self, hostname, port, experiment_id):
-        self.base_url = "http://" + hostname + ":" + str(port) + "/api/2.0/mlflow"
+        self.base_url = "http://" + hostname + ":" + str(port) + "/ajax-api/2.0/mlflow"
         self.experiment_id = experiment_id
         self.run_id = self.create_run()
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -234,7 +234,7 @@ def _get_proxied_run_artifact_destination_path(proxied_artifact_root, relative_p
         # `/api/2.0/mlflow-artifacts/artifacts`. Accordingly, we split the path on this route anchor
         # and interpret the rest of the path (everything after the route anchor) as the run artifact
         # root path
-        mlflow_artifacts_http_route_anchor = "/api/2.0/mlflow-artifacts/artifacts/"
+        mlflow_artifacts_http_route_anchor = "/ajax-api/2.0/mlflow-artifacts/artifacts/"
         assert mlflow_artifacts_http_route_anchor in parsed_proxied_artifact_root.path
 
         proxied_run_artifact_root_path = parsed_proxied_artifact_root.path.split(

--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -46,7 +46,7 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
 
     @classmethod
     def resolve_uri(cls, artifact_uri, tracking_uri):
-        base_url = "/api/2.0/mlflow-artifacts/artifacts"
+        base_url = "/ajax-api/2.0/mlflow-artifacts/artifacts"
 
         track_parse = urlparse(tracking_uri)
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -22,7 +22,7 @@ from mlflow.environment_variables import (
 )
 
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
-_REST_API_PATH_PREFIX = "/api/2.0"
+_REST_API_PATH_PREFIX = "/ajax-api/2.0"
 
 
 def http_request(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
